### PR TITLE
fix: enable regex literals

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,10 +28,13 @@ let package = Package(
         .executableTarget(
             name: "AdventOfCode",
             dependencies: dependencies,
-            resources: [.copy("Data")]),
+            resources: [.copy("Data")],
+            swiftSettings: [.enableUpcomingFeature("BareSlashRegexLiterals")]
+        ),
         .testTarget(
             name: "AdventOfCodeTests",
-            dependencies: ["AdventOfCode"] + dependencies
+            dependencies: ["AdventOfCode"] + dependencies,
+            swiftSettings: [.enableUpcomingFeature("BareSlashRegexLiterals")]
         )
     ]
 )


### PR DESCRIPTION
This PR enables [bare regex literals](https://github.com/apple/swift-evolution/blob/main/proposals/0354-regex-literals.md) in the SPM package, which is a [source breaking change](https://github.com/apple/swift-evolution/blob/main/proposals/0354-regex-literals.md#source-compatibility) and as such needs to be enabled by passing in a compiler flag.

This allows writing regular expressions in code like below, which is super useful for Advent of Code.

```swift
let regex = /(.)*|\d/
```