### PR TITLE
Add iOS, watchOS and tvOS min targets to Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let dependencies: [Target.Dependency] = [
 
 let package = Package(
     name: "AdventOfCode",
-    platforms: [.macOS(.v13)],
+    platforms: [.macOS(.v13), .iOS(.v16), .watchOS(.v9), .tvOS(.v16)],
     dependencies: [
         .package(
             url: "https://github.com/apple/swift-algorithms.git",


### PR DESCRIPTION
The package uses async/await, ContinuousClock and some other API only available from iOS 16.

Right now Package.swift doesn't specify minimum supported targets for all the platforms except for macOS, so trying to clone and build the repo in Xcode can result in errors, even though you can run the main executable target on any platforms, including iOS.

Even though it's not common to run executable targets on iOS/tvOS or watchOS, some developers use AOC as an opportunity to try a new language, in our case Swift, it would be nice to make the setup process as smooth as possible.