### PR TITLE
fix path; add Data to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ DerivedData/
 .netrc
 lcov.info
 Package.resolved
+Sources/Data/Day*.txt

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ extensions useful:
 
 The challenges assume three files (replace 00 with the day of the challenge).
 
-- `Data/Day00.txt`: the input data provided for the challenge
+- `Sources/Data/Day00.txt`: the input data provided for the challenge
 - `Sources/Day00.swift`: the code to solve the challenge
 - `Tests/Day00.swift`: any unit tests that you want to include
 


### PR DESCRIPTION
As Eric Wastl [explicitly asks to not share puzzle inputs](https://www.reddit.com/r/adventofcode/wiki/faqs/copyright/inputs), the corresponding files should be added to `.gitignore`. I also fixed the path mentioned in `README`