### PR TITLE
Update for Swift6, Swift testing and add editor config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# editorconfig.org
+
+root = true
+
+[*.swift]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/Package.swift
+++ b/Package.swift
@@ -1,40 +1,39 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 import PackageDescription
 
 let dependencies: [Target.Dependency] = [
-    .product(name: "Algorithms", package: "swift-algorithms"),
-    .product(name: "Collections", package: "swift-collections"),
-    .product(name: "ArgumentParser", package: "swift-argument-parser"),
+  .product(name: "Algorithms", package: "swift-algorithms"),
+  .product(name: "Collections", package: "swift-collections"),
+  .product(name: "ArgumentParser", package: "swift-argument-parser"),
 ]
 
 let package = Package(
-    name: "AdventOfCode",
-    platforms: [.macOS(.v13)],
-    dependencies: [
-        .package(
-            url: "https://github.com/apple/swift-algorithms.git",
-            .upToNextMajor(from: "1.2.0")),
-        .package(
-            url: "https://github.com/apple/swift-collections.git",
-            .upToNextMajor(from: "1.0.0")),
-        .package(
-            url: "https://github.com/apple/swift-argument-parser.git",
-            .upToNextMajor(from: "1.2.0")),
-        .package(
-            url: "https://github.com/apple/swift-format.git",
-            .upToNextMajor(from: "509.0.0"))
-    ],
-    targets: [
-        .executableTarget(
-            name: "AdventOfCode",
-            dependencies: dependencies,
-            resources: [.copy("Data")],
-            swiftSettings: [.enableUpcomingFeature("BareSlashRegexLiterals")]
-        ),
-        .testTarget(
-            name: "AdventOfCodeTests",
-            dependencies: ["AdventOfCode"] + dependencies,
-            swiftSettings: [.enableUpcomingFeature("BareSlashRegexLiterals")]
-        )
-    ]
+  name: "AdventOfCode",
+  platforms: [.macOS(.v13)],
+  dependencies: [
+    .package(
+      url: "https://github.com/apple/swift-algorithms.git",
+      .upToNextMajor(from: "1.2.0")),
+    .package(
+      url: "https://github.com/apple/swift-collections.git",
+      .upToNextMajor(from: "1.1.4")),
+    .package(
+      url: "https://github.com/apple/swift-argument-parser.git",
+      .upToNextMajor(from: "1.5.0")),
+    .package(
+      url: "https://github.com/apple/swift-format.git",
+      .upToNextMajor(from: "600.0.0"))
+  ],
+  targets: [
+    .executableTarget(
+      name: "AdventOfCode",
+      dependencies: dependencies,
+      resources: [.copy("Data")]
+    ),
+    .testTarget(
+      name: "AdventOfCodeTests",
+      dependencies: ["AdventOfCode"] + dependencies
+    )
+  ],
+  swiftLanguageModes: [.v6]
 )

--- a/Sources/AdventDay.swift
+++ b/Sources/AdventDay.swift
@@ -2,7 +2,7 @@
 @_exported import Collections
 import Foundation
 
-protocol AdventDay {
+protocol AdventDay: Sendable {
   associatedtype Answer = Int
 
   /// The day of the Advent of Code challenge.

--- a/Tests/AdventDay.swift
+++ b/Tests/AdventDay.swift
@@ -1,11 +1,12 @@
-import XCTest
+import Testing
 
 @testable import AdventOfCode
 
 // One off test to validate that basic data load testing works
-final class AdventDayTests: XCTestCase {
-  func testInitData() throws {
+struct AdventDayTests {
+
+  @Test func testInitData() async throws {
     let challenge = Day00()
-    XCTAssertTrue(challenge.data.starts(with: "4514"))
+    #expect(challenge.data.starts(with: "4514"))
   }
 }

--- a/Tests/Day00.swift
+++ b/Tests/Day00.swift
@@ -1,10 +1,10 @@
-import XCTest
+import Testing
 
 @testable import AdventOfCode
 
 // Make a copy of this file for every day to ensure the provided smoke tests
 // pass.
-final class Day00Tests: XCTestCase {
+struct Day00Tests {
   // Smoke test data provided in the challenge question
   let testData = """
     1000
@@ -24,13 +24,13 @@ final class Day00Tests: XCTestCase {
 
     """
 
-  func testPart1() throws {
+  @Test func testPart1() async throws {
     let challenge = Day00(data: testData)
-    XCTAssertEqual(String(describing: challenge.part1()), "6000")
+    #expect(String(describing: challenge.part1()) == "6000")
   }
 
-  func testPart2() throws {
+  @Test func testPart2() async throws {
     let challenge = Day00(data: testData)
-    XCTAssertEqual(String(describing: challenge.part2()), "32000")
+    #expect(String(describing: challenge.part2()) == "32000")
   }
 }


### PR DESCRIPTION
Update the repo to Swift 6, dropped support for Swift 5 (might be worth a discussion): updated Swift-tools and dependencies, added a Sendable conformance for the projet to build with Swift 6.

Converted tests to Swift-testing.

Added Editor config, formatted some files though I didn't know what would be the appropriate tab length as some files were 4 and other 2. Also Xcode format some lines differently than swift-format. As Swift-format is mentioned in the README, I kept its format.

Happy Swift AOC !

